### PR TITLE
Changes needed while testing the exercises

### DIFF
--- a/CSC/setup
+++ b/CSC/setup
@@ -5,5 +5,5 @@
 #export LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/views/LCG_100/x86_64-centos7-gcc9-opt/lib/
 
 # for CSC 2023 on csc-2023 - drop these two lines if running on your own machine
-source /cvmfs/sft.cern.ch/lcg/views/LCG_100/x86_64-centos7-gcc10-dbg/setup.sh
-export LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/views/LCG_100/x86_64-centos7-gcc10-dbg/lib/
+source /cvmfs/sft.cern.ch/lcg/views/LCG_100/x86_64-centos8-gcc10-dbg/setup.sh
+export LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/views/LCG_100/x86_64-centos8-gcc10-dbg/lib/


### PR DESCRIPTION
- use centos8 for the LCG stack (to be consistent with instructions to use lxplus8)
- 